### PR TITLE
Restored Italian and translated tooltip title

### DIFF
--- a/CategorySuggest.body.php
+++ b/CategorySuggest.body.php
@@ -52,6 +52,7 @@ global $wgOut, $wgParser, $wgTitle, $wgRequest;
 	$arrExistingCats = $m_pageCats;
 
 	#ADD JAVASCRIPT - use document.write so it is not presented if javascript is disabled.
+	$m_pageObj->$m_place .= "<script type=\"text/javascript\">/*<![CDATA[*/ var categorysuggestSelect = \"". wfMessage( 'categorysuggest-select' )->text() ."\"; /*]]>*/</script>\n";
 	$m_pageObj->$m_place .= "<script type=\"text/javascript\" src=\"" . $wgCategorySuggestjs . "\"></script>\n";
 	$m_pageObj->$m_place .= "<script type=\"text/javascript\">/*<![CDATA[*/\n";
 	$m_pageObj->$m_place .= "document.write(\"<div id='categoryselectmaster'><div><b>" .wfMsg( 'categorysuggest-title' ). "</b></div>\");\n";

--- a/CategorySuggest.i18n.php
+++ b/CategorySuggest.i18n.php
@@ -27,15 +27,15 @@ $messages = array(
 		'categorysuggest-select' => 'Klicken Sie hier, um die Kategorie in der Kategorieliste für diese Seite!'
 	),
 
-  'fr' => array(
-    'categorysuggest-title' => 'CHOIX DES CATEGORIES (tags)',
-    'categorysuggest-subtitle' => 'Veuillez saisir le nom d\'une catégorie (tag) pour cet article.',
-    'categorysuggest-boxlabel' => 'Catégories',
-    'categorysuggest-taglabel' => 'Catégories populaires'
-    'categorysuggest-select' => 'Cliquez pour ajouter cette catégorie à la liste pour la page!'
-  ),
+	'fr' => array(
+		'categorysuggest-title' => 'CHOIX DES CATEGORIES (tags)',
+		'categorysuggest-subtitle' => 'Veuillez saisir le nom d\'une catégorie (tag) pour cet article.',
+		'categorysuggest-boxlabel' => 'Catégories',
+		'categorysuggest-taglabel' => 'Catégories populaires',
+		'categorysuggest-select' => 'Cliquez pour ajouter cette catégorie à la liste pour la page!'
+  	),
 
-  'it' => array(
+  	'it' => array(
 		'categorysuggest-title' => 'ASSEGNAZIONE CATEGORIE',
 		'categorysuggest-subtitle' => 'Digitare il nome di una categoria per questo articolo.',
 		'categorysuggest-boxlabel' => 'Categorie',

--- a/CategorySuggest.i18n.php
+++ b/CategorySuggest.i18n.php
@@ -9,19 +9,37 @@
  * @description
  *
 */
-$messages = array();
+$messages = array(
 
-$messages['en']['categorysuggest-title']	= 'CATEGORY ASSIGNMENT';
-$messages['en']['categorysuggest-subtitle']	= 'Please enter the name of a category for this article.';
-$messages['en']['categorysuggest-boxlabel']	= 'Categories';
-$messages['en']['categorysuggest-taglabel']	= 'Popular Categories';
+	'en' => array(
+		'categorysuggest-title' => 'CATEGORY ASSIGNMENT',
+		'categorysuggest-subtitle' => 'Please enter the name of a category for this article.',
+		'categorysuggest-boxlabel' => 'Categories',
+		'categorysuggest-taglabel' =>'Popular Categories',
+		'categorysuggest-select' => 'Click here to add category to the category list for this page!'
+	),
 
-$messages['de']['categorysuggest-title']        = 'KATEGORIE VERGABE';
-$messages['de']['categorysuggest-subtitle']     = 'Bitte fügen Sie den Namen der Kategorie ein.';
-$messages['de']['categorysuggest-boxlabel']     = 'Kategorien';
-$messages['de']['categorysuggest-taglabel']     = 'Beliebte Kategorie';
+	'de' => array(
+		'categorysuggest-title' => 'KATEGORIE VERGABE',
+		'categorysuggest-subtitle' => 'Bitte fügen Sie den Namen der Kategorie ein.',
+		'categorysuggest-boxlabel' => 'Kategorien',
+		'categorysuggest-taglabel' => 'Beliebte Kategorie',
+		'categorysuggest-select' => 'Klicken Sie hier, um die Kategorie in der Kategorieliste für diese Seite!'
+	),
 
-$messages['fr']['categorysuggest-title']        = 'CHOIX DES CATEGORIES (tags)';
-$messages['fr']['categorysuggest-subtitle']     = 'Veuillez saisir le nom d\'une catégorie (tag) pour cet article.';
-$messages['fr']['categorysuggest-boxlabel']     = 'Catégories';
-$messages['fr']['categorysuggest-taglabel']     = 'Catégories populaires';
+  'fr' => array(
+    'categorysuggest-title' => 'CHOIX DES CATEGORIES (tags)',
+    'categorysuggest-subtitle' => 'Veuillez saisir le nom d\'une catégorie (tag) pour cet article.',
+    'categorysuggest-boxlabel' => 'Catégories',
+    'categorysuggest-taglabel' => 'Catégories populaires'
+    'categorysuggest-select' => 'Cliquez pour ajouter cette catégorie à la liste pour la page!'
+  ),
+
+  'it' => array(
+		'categorysuggest-title' => 'ASSEGNAZIONE CATEGORIE',
+		'categorysuggest-subtitle' => 'Digitare il nome di una categoria per questo articolo.',
+		'categorysuggest-boxlabel' => 'Categorie',
+		'categorysuggest-taglabel' => 'Categorie più utilizzate',
+		'categorysuggest-select' => 'Clicca per aggiungere la categoria all\'elenco per questa pagina!'
+	)
+);

--- a/CategorySuggest.i18n.php
+++ b/CategorySuggest.i18n.php
@@ -16,7 +16,7 @@ $messages = array(
 		'categorysuggest-subtitle' => 'Please enter the name of a category for this article.',
 		'categorysuggest-boxlabel' => 'Categories',
 		'categorysuggest-taglabel' =>'Popular Categories',
-		'categorysuggest-select' => 'Click here to add category to the category list for this page!'
+		'categorysuggest-select' => 'Click here to add category to the list for this page!'
 	),
 
 	'de' => array(
@@ -24,7 +24,7 @@ $messages = array(
 		'categorysuggest-subtitle' => 'Bitte fügen Sie den Namen der Kategorie ein.',
 		'categorysuggest-boxlabel' => 'Kategorien',
 		'categorysuggest-taglabel' => 'Beliebte Kategorie',
-		'categorysuggest-select' => 'Klicken Sie hier, um die Kategorie in der Kategorieliste für diese Seite!'
+		'categorysuggest-select' => 'Klicken Sie hier, um die Kategorie in der Kategorieliste für diese Seite!' // translation attempt (not mother language)
 	),
 
 	'fr' => array(
@@ -32,7 +32,7 @@ $messages = array(
 		'categorysuggest-subtitle' => 'Veuillez saisir le nom d\'une catégorie (tag) pour cet article.',
 		'categorysuggest-boxlabel' => 'Catégories',
 		'categorysuggest-taglabel' => 'Catégories populaires',
-		'categorysuggest-select' => 'Cliquez pour ajouter cette catégorie à la liste pour la page!'
+		'categorysuggest-select' => 'Cliquez pour ajouter cette catégorie à la liste pour la page!' // translation attempt (not mother language)
   	),
 
   	'it' => array(

--- a/CategorySuggest.js
+++ b/CategorySuggest.js
@@ -76,7 +76,7 @@ function sendRequest(q,e) {
 					result.onmouseover = highlight;
 					result.onmouseout = unHighlight;
 					result.onmousedown = selectEntry;
-					result.title = 'Click here to add category to the category list!';
+					result.title = categorysuggestSelect;
 					result.className="cs";
 					resultDiv.style.lineHeight='1';
 					resultDiv.appendChild(result);


### PR DESCRIPTION
@title for the suggestion list has been translated and inserted via a <script> tag, so it can be shown in the correct language.
Note
When the French translation has been inserted, the Italian lines have gone lost. I have restored it, along with the missing line for all the languages. The English line has been copypasted from the original (just removed a repeated word) and Italian is my mother language. French is a good attempt, but German has been googled.
Also, the structure of i18n seems lighter now.