### PR TITLE
Resolved merge conflicts.

### DIFF
--- a/CategorySuggest.body.php
+++ b/CategorySuggest.body.php
@@ -16,7 +16,7 @@ if(!defined('MEDIAWIKI')) {
 ## Entry point for the hook and main worker function for editing the page:
 function fnCategorySuggestShowHook($m_isUpload = false, &$m_pageObj) {
 	global $wgTitle, $wgRequest;
-	global $wgScriptPath, $wgCategorySuggestCloud, $wgCategorySuggestjs;
+	global $wgScriptPath, $wgCategorySuggestCloud;
 
 	# Get ALL categories from wiki:
 //		$m_allCats = fnAjaxSuggestGetAllCategories();
@@ -48,10 +48,9 @@ function fnCategorySuggestShowHook($m_isUpload = false, &$m_pageObj) {
 
 	$catList = htmlspecialchars(str_replace('_',' ',implode(';', $catList)));
 	if (!empty($catList)) {
-		$catList .= ';';		
+		$catList .= ';';
 	}
 	$extCategoryField = '<script type="text/javascript">/*<![CDATA[*/ var categorysuggestSelect = "'. wfMessage('categorysuggest-select')->text() .'"; /*]]>*/</script>' .
-		'<script type="text/javascript" src="' . $wgCategorySuggestjs . '"></script>' .
 		'<div id="categoryselectmaster"><div><b>' .wfMsg('categorysuggest-title'). '</b></div>' .
 		'<table><caption>' . wfMsg('categorysuggest-subtitle'). '</caption><tbody>' .
 		'<tr><th><label for="txtSelectedCategories">' .wfMsg('categorysuggest-boxlabel').':</label></th>' .
@@ -94,23 +93,6 @@ function fnCategorySuggestSaveHook($m_isUpload, $m_pageObj) {
 	}
 
 	# Return to the let MediaWiki do the rest of the work:
-	return true;
-}
-
-/*************************************************************************************/
-## Entry point for the CSS:
-function fnCategorySuggestOutputHook(&$m_pageObj, $m_parserOutput) {
-	global $wgScriptPath, $wgCategorySuggestcss;
-
-	# Register CSS file for input box:
-	$m_pageObj->addLink(
-		array(
-			'rel'	=> 'stylesheet',
-			'type'	=> 'text/css',
-			'href'	=> $wgCategorySuggestcss
-		)
-	);
-
 	return true;
 }
 

--- a/CategorySuggest.js
+++ b/CategorySuggest.js
@@ -12,7 +12,7 @@
 var csQuery = '';
 addEvent(document, "mouseup",keyPressHandler);
 
-function sendRequest(q,e) {
+window.sendRequest = function(q,e) {
 	if ([e.keyCode||e.which] == 27 ) {
 		var resultDiv = document.getElementById('searchResults');
 		resultDiv.style.visibility = 'hidden';
@@ -86,7 +86,6 @@ function sendRequest(q,e) {
 	}
 }
 
-
 // SELECT CATEGORY FROM SUGGEST DIV AND ADD IT TO THE INPUT BOX
 function selectEntry () {
 	  	var strExistingValues = document.getElementById('txtSelectedCategories').value;
@@ -149,7 +148,7 @@ function addEvent(el, sEvt, PFnc)
       //}
    }
 
-function checkSelect(input, event) {
+window.checkSelect = function(input, event) {
 	switch (event.keyCode) {
 		case 40: // Down Arrow
 		case 38: // Up Arrow

--- a/CategorySuggest.php
+++ b/CategorySuggest.php
@@ -45,6 +45,21 @@ $wgExtensionCredits['parserhook'][] = array(
 );
 $wgExtensionMessagesFiles['CategorySuggest'] = dirname(__FILE__) . '/CategorySuggest.i18n.php';
 
+$wgResourceModules['ext.CategorySuggest'] = array(
+	'scripts' => 'CategorySuggest.js',
+	'styles' => 'CategorySuggest.css',
+	'position' => 'bottom',
+	'localBasePath' => __DIR__,
+	'remoteExtPath' => 'CategorySuggest'
+);
+
+$wgHooks['BeforePageDisplay'][] = 'fnCategorySuggestAddModules';
+
+function fnCategorySuggestAddModules( &$out, $skin = false ) {
+	$out->addModules( 'ext.CategorySuggest' );
+	return true;
+}
+
 
 ## register Ajax function to be called from Javascript file
 $wgAjaxExportList[] = 'fnCategorySuggestAjax';
@@ -101,8 +116,6 @@ function fnCategorySuggest() {
 	$wgHooks['UploadForm:BeforeProcessing'][] = array( 'fnCategorySuggestSaveHook', true );
 
 	## Infrastructure
-	# Hook our own CSS:
-	$wgHooks['OutputPageParserOutput'][] = 'fnCategorySuggestOutputHook';
 	# Hook up local messages:
 	$wgHooks['LoadAllMessages'][] = 'fnCategorySuggestMessageHook';
 }


### PR DESCRIPTION
This branch removes the local inclusion of JavaScript and CSS from the hook system and moves it into [the ResourceModules API](https://www.mediawiki.org/wiki/Manual:$wgResourceModules). The need for this change is that jQuery is now included by MediaWiki at the bottom of every page, rather than the top to prevent blocking. Script relying on jQuery should be loaded through the ResourceModules, ensuring that they are included after jQuery.

However, this also takes the functions declared in our custom script out of the global scope and so the two referred to in the action attributes of the form need to be attached to the window object, bringing them back into global scope.