### PR TITLE
Fix index in fnCategorySuggestGetPageCategories

### DIFF
--- a/CategorySuggest.body.php
+++ b/CategorySuggest.body.php
@@ -120,6 +120,7 @@ function fnCategorySuggestGetPageCategories($m_pageObj) {
 	foreach($m_pageText as $i => $block) {
 		$preventCheck = true;
 		$skip = 0;
+		$index = '';
 		switch($block){
 			// If we encounter a <nowiki>, <noinclude>, <includeonly> or <onlyinclude> tag, or a template opening string, add it to our stacks.
 			case '{{' :
@@ -145,8 +146,8 @@ function fnCategorySuggestGetPageCategories($m_pageObj) {
 
 			default :
 				$preventCheck = false;
-				foreach($stacklist as $index){
-					if(!empty($index)) $preventCheck = true;
+				foreach($stacklist as $stack){
+					if(!empty($stack)) $preventCheck = true;
 				}
 				break;
 		}


### PR DESCRIPTION
There are currently two issues with $index in fnCategorySuggestGetPageCategories that result in PHP warnings ("invalid offset type" and "array_pop() expects parameter 1 to be array").

Here is an example that consistently produces warnings for me:
`{{<nowiki></nowiki>}}`

1. The foreach-loop inside the default case reuses $index to iterate over stacks, effectively replacing the string by an array. The last array stays in the variable and is used on the next iteration (see point 2.). This is fixed by using a different variable name.

2. $index is never initialized. This means, that it will always keep the value of the first positive match ('template' in the example above). Subsequent checks for `$index = ($index) ? $index : substr(...)` will always return $index. This results in a stacklist with exactly one stack inside (as opposed to multiple stacks for each type of element). Note that, because of point 1., $index will be an array on the next iteration, which causes the warnings above.